### PR TITLE
fix: restore hyperlinks on sign-up and docs bullet points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,137 +1,274 @@
 # Run SmartUI Storybook Tests on TestMu AI (Formerly LambdaTest)
 
+
+
 <p align="center">
+
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+
   <a href="https://www.npmjs.com/package/@lambdatest/smartui-storybook"><img src="https://img.shields.io/npm/v/@lambdatest/smartui-storybook.svg?style=for-the-badge&labelColor=000000" alt="npm version"></a>
+
   <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+
 </p>
+
+
 
 ## Getting Started
 
+
+
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
+
+
 
 With TestMu AI (Formerly LambdaTest), you can run SmartUI visual regression tests for Storybook components across real browsers and operating systems using the `@lambdatest/smartui-storybook` CLI.
 
-- Sign up on TestMu AI (Formerly LambdaTest).
-- Follow the TestMu AI Documentation for the full setup walkthrough.
+
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
+
+
 
 ### Prerequisites
 
+
+
 1. Basic understanding of Storybook.
+
 2. Node.js version higher than `14.15.0`. See Node.js releases.
+
 3. Storybook version higher than `6.4.0`. See Storybook releases.
+
 4. A TestMu AI account — sign up here and log into TestMu AI SmartUI.
+
+
 
 ### Setup
 
+
+
 Clone the repository:
 
+
+
 ```bash
+
 git clone https://github.com/LambdaTest/smartui-storybook
+
 cd smartui-storybook
+
 ```
+
+
 
 Install the SmartUI Storybook CLI globally:
 
+
+
 ```bash
+
 npm install @lambdatest/smartui-storybook -g
+
 ```
+
+
 
 Add the following to your `.storybook/main.js`:
 
+
+
 ```javascript
+
 module.exports = {
+
   features: {
+
     buildStoriesJson: true,
+
   },
+
 };
+
 ```
+
+
 
 Create a SmartUI project at the Projects page, then set your project token:
 
+
+
 - For Linux/macOS:
 
+
+
 ```bash
+
 export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
+
 ```
+
+
 
 - For Windows:
 
+
+
 ```bash
+
 set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
+
 ```
+
+
 
 Generate the SmartUI configuration file:
 
+
+
 ```bash
+
 smartui config create .smartui.json
+
 ```
+
+
 
 ### Run tests
 
+
+
 Execute visual regression tests on your Storybook components:
 
+
+
 ```bash
+
 smartui storybook http://localhost:6006 --config .smartui.json
+
 ```
+
+
 
 You can also provide a path to the `storybook-static` directory instead of the local Storybook URL. Use `--help` for more information.
 
+
+
 ### Local testing with TestMu AI Tunnel
+
+
 
 To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
+
+
 - [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+
 - [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+
 - [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+
 
 Configure tunnel in your SmartUI config:
 
+
+
 ```json
+
 {
+
   "tunnel": true
+
 }
+
 ```
+
+
 
 ## Contributions
 
+
+
 Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and npm version.
+
+
 
 ## TestMu AI (Formerly LambdaTest) Community
 
+
+
 Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+
   
+
 ## TestMu AI (Formerly LambdaTest) Certifications
+
+
 
 Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
+
+
 ## Learning Resources by TestMu AI (Formerly LambdaTest)
+
+
 
 Learn modern testing through tutorials, guides, videos, and weekly updates:
 
+
+
 * [TestMu AI Blog](https://www.testmuai.com/blog/)
+
 * [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+
 * [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+
 * [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+
   
+
 ## LambdaTest is Now TestMu AI
+
+
 
 On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
+
+
 Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
+
+
 
 ð Find the new home for [LambdaTest](https://www.testmuai.com).
 
+
+
 ### How LambdaTest Evolved into TestMu AI
+
+
 
 In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
+
+
 As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
+
+
 
 That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
+
+
 What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+
 
 ## Support
 
+
+
 Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.
+


### PR DESCRIPTION
Restores the markdown hyperlinks on the sign-up and documentation bullet points under Getting Started that were incorrectly stripped to plain text.